### PR TITLE
[#17] Add strong_migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem 'spring'
+  gem 'strong_migrations', '~> 1.0.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,8 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.0.4)
       railties (>= 6.0.0)
+    strong_migrations (1.0.0)
+      activerecord (>= 5.2)
     strscan (3.0.3)
     thor (1.2.1)
     timeout (0.3.0)
@@ -247,6 +249,7 @@ DEPENDENCIES
   shoulda-matchers (~> 5.0)
   sprockets-rails
   stimulus-rails
+  strong_migrations (~> 1.0.0)
   turbo-rails
   tzinfo-data
   web-console

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,26 @@
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20220604103854
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true


### PR DESCRIPTION
[strong_migrations](https://github.com/ankane/strong_migrations) is a gem that help us to flag dangerous operations inside migrations :)

It will run automatically whenever we run `rails db:migrate`.
