### PR TITLE
[#19] Add annotate gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,10 @@ AllCops:
   Exclude:
     - 'bin/bundle'
     - 'db/schema.rb'
+    - 'lib/tasks/auto_annotate_models.rake'
+
+Lint/RedundantCopDisableDirective:
+  Enabled: false
 
 Layout/LineLength:
   Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem 'spring'
+  gem 'annotate', '~> 3.2.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     bindex (0.8.1)
     bootsnap (1.12.0)
@@ -298,6 +301,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate (~> 3.2.0)
   bootsnap
   brakeman (~> 5.2.3)
   bullet (~> 7.0.2)

--- a/app/models/item_season.rb
+++ b/app/models/item_season.rb
@@ -10,3 +10,25 @@ class ItemSeason < ApplicationRecord
 
   validates :month_index, :country_code, presence: true
 end
+
+# rubocop:disable Layout/LineLength
+# == Schema Information
+#
+# Table name: item_seasons
+#
+#  id              :bigint           not null, primary key
+#  month_index     :integer          not null
+#  country_code    :string           not null
+#  produce_item_id :bigint           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_item_seasons_on_produce_item_id  (produce_item_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (produce_item_id => produce_items.id)
+#
+# rubocop:enable Layout/LineLength

--- a/app/models/produce_item.rb
+++ b/app/models/produce_item.rb
@@ -9,3 +9,20 @@ class ProduceItem < ApplicationRecord
   validates :name, presence: true
   validates :category, presence: true
 end
+
+# rubocop:disable Layout/LineLength
+# == Schema Information
+#
+# Table name: produce_items
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  category   :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_produce_items_on_name  (name) UNIQUE
+#
+# rubocop:enable Layout/LineLength

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'after',
+      'position_in_class'           => 'after',
+      'position_in_test'            => 'after',
+      'position_in_fixture'         => 'after',
+      'position_in_factory'         => 'after',
+      'position_in_serializer'      => 'after',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'false',
+      'trace'                       => 'false',
+      'wrapper_open'                => 'rubocop:disable Layout/LineLength',
+      'wrapper_close'               => 'rubocop:enable Layout/LineLength',
+      'with_comment'                => 'false'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/models/item_season_spec.rb
+++ b/spec/models/item_season_spec.rb
@@ -14,3 +14,25 @@ RSpec.describe ItemSeason, type: :model do
     it { is_expected.to belong_to(:produce_item).without_validating_presence }
   end
 end
+
+# rubocop:disable Layout/LineLength
+# == Schema Information
+#
+# Table name: item_seasons
+#
+#  id              :bigint           not null, primary key
+#  month_index     :integer          not null
+#  country_code    :string           not null
+#  produce_item_id :bigint           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_item_seasons_on_produce_item_id  (produce_item_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (produce_item_id => produce_items.id)
+#
+# rubocop:enable Layout/LineLength

--- a/spec/models/produce_item_spec.rb
+++ b/spec/models/produce_item_spec.rb
@@ -32,3 +32,20 @@ RSpec.describe ProduceItem, type: :model do
 
   it { is_expected.to have_many(:item_seasons) }
 end
+
+# rubocop:disable Layout/LineLength
+# == Schema Information
+#
+# Table name: produce_items
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  category   :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_produce_items_on_name  (name) UNIQUE
+#
+# rubocop:enable Layout/LineLength


### PR DESCRIPTION
closes #19 

[annotate](https://github.com/ctran/annotate_models) is a gem that adds table schemas as comments at several files in our projects. This saves a trip to schema.rb whenever we want to check our table schemas.
