### PR TITLE
Feature/45/item seasons/index/frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 /config/master.key
 coverage/
 .env
+
+# Ignore DS Store
+**/.DS_Store

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,16 +14,15 @@
  *= require_self
  */
 
+@import "components/banner-small";
 @import "components/button-holder";
 @import "components/buttons";
+@import "components/content";
 @import "components/footer";
 @import "components/navbar";
 @import "config/base";
+@import "config/colors";
 @import "config/fonts";
 @import "config/rotations";
 @import "config/spaces";
 @import "pages/homepage.css";
-
-.content {
-  flex: 1 0 auto;
-}

--- a/app/assets/stylesheets/components/_banner-small.css
+++ b/app/assets/stylesheets/components/_banner-small.css
@@ -1,0 +1,7 @@
+.banner-small {
+  margin-top: var(--size-nav);
+  background-image: url("https://dsm01pap009files.storage.live.com/y4mcm1lmTkF2KIVBJC3iu7OT4Ppioc9PJDcUXJXpY6C71sEwZuYlugJi8UCOmoRCEgrxmsxmGVMC86MWv4ftWsR5ZzoeSQBlhSroZ_SG1Th-S_Nd33jhwnjJ_m0T-p2KR8tLbeIDMPvPV4Y33ddsmRVNCMJKZfI997J_-Rp8cjT5rEPs_ss58F1UJBCTzqHhahI?width=1600&height=1200&cropmode=none");
+  background-size: 100vw;
+  color: white;
+  text-align: center;
+}

--- a/app/assets/stylesheets/components/_banner-small.css
+++ b/app/assets/stylesheets/components/_banner-small.css
@@ -4,4 +4,6 @@
   background-size: 100vw;
   color: white;
   text-align: center;
+  padding-top: var(--spaces-size-m);
+  padding-bottom: var(--spaces-size-m);
 }

--- a/app/assets/stylesheets/components/_content.css
+++ b/app/assets/stylesheets/components/_content.css
@@ -1,0 +1,3 @@
+.content {
+  flex: 1 0 auto;
+}

--- a/app/assets/stylesheets/config/_base.css
+++ b/app/assets/stylesheets/config/_base.css
@@ -29,6 +29,10 @@
   border: 0.5px solid blue;
 }
 
+html, body {
+  height: 100%;
+}
+
 html {
     /*
   This allows us to use readable rems.

--- a/app/assets/stylesheets/config/_base.css
+++ b/app/assets/stylesheets/config/_base.css
@@ -15,6 +15,7 @@
   --spaces-size-s:1.5rem;
   --spaces-size-m:3rem;
   --spaces-size-l:6rem;
+  --size-nav:10rem;
 }
 
 *, *::before, *::after {

--- a/app/assets/stylesheets/config/_colors.css
+++ b/app/assets/stylesheets/config/_colors.css
@@ -1,0 +1,11 @@
+.background-color-yellow {
+  background-color: var(--color--yellow);
+}
+
+.background-color-red {
+  background-color: var(--color--red);
+}
+
+.background-color-blue {
+  background-color: var(--color--blue);
+}

--- a/app/assets/stylesheets/pages/homepage.css
+++ b/app/assets/stylesheets/pages/homepage.css
@@ -10,7 +10,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-top: 10rem;
+  margin-top: var(--size-nav);
 }
 
 .banner-hero__txt {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,4 +4,8 @@ module ApplicationHelper
   def formatted_month_name(month_index)
     I18n.t('date.month_names')[month_index].downcase
   end
+
+  def formatted_month_short(month_index)
+    I18n.t('date.month_short')[month_index].downcase
+  end
 end

--- a/app/helpers/item_seasons_helper.rb
+++ b/app/helpers/item_seasons_helper.rb
@@ -2,7 +2,7 @@
 
 module ItemSeasonsHelper
   def sampled_rotation
-    ["rotate-zero", "rotate-plus-5", "rotate-plus-10", "rotate-plus-15",
-      "rotate-minus-5", "rotate-minus-10", "rotate-minus-15"].sample
+    %w[rotate-zero rotate-plus-5 rotate-plus-10 rotate-plus-15
+       rotate-minus-5 rotate-minus-10 rotate-minus-15].sample
   end
 end

--- a/app/helpers/item_seasons_helper.rb
+++ b/app/helpers/item_seasons_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ItemSeasonsHelper
-  def sampled_rotation
+  def randomized_rotation
     %w[rotate-zero rotate-plus-5 rotate-plus-10 rotate-plus-15
        rotate-minus-5 rotate-minus-10 rotate-minus-15].sample
   end

--- a/app/helpers/item_seasons_helper.rb
+++ b/app/helpers/item_seasons_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ItemSeasonsHelper
+  def sampled_rotation
+    ["rotate-zero", "rotate-plus-5", "rotate-plus-10", "rotate-plus-15",
+      "rotate-minus-5", "rotate-minus-10", "rotate-minus-15"].sample
+  end
+end

--- a/app/views/home_page/index.html.erb
+++ b/app/views/home_page/index.html.erb
@@ -1,27 +1,29 @@
-<section class="banner-hero p-top-l p-bottom-l p-sides-m">
-  <div class="script-md banner-hero__txt"><%= I18n.t('root.hero') %></div>
-</section>
+<div class="content">
+  <section class="banner-hero p-top-l p-bottom-l p-sides-m">
+    <div class="script-md banner-hero__txt"><%= I18n.t('root.hero') %></div>
+  </section>
 
-<section class="banner-buttons p-top-m p-bottom-l p-sides-m">
-  <div class="p-bottom-m">
-    <h3 class="color-yellow"><%= I18n.t('action.search_by') %></h3>
-  </div>
-  <div class="button-holder">
-      <%= link_to I18n.t('action.month').capitalize, item_seasons_path, class: 'link_action button button--yellow script-lg rotate-minus-5' %>
-      <%= link_to I18n.t('action.produce').capitalize, produce_items_path, class: 'link_action button button--yellow script-lg rotate-zero' %>
-  </div>
-</section>
-
-<section class="banner-about p-top-m p-bottom-l">
-  <%= image_tag "https://dm2305files.storage.live.com/y4mYqMHpvb-2aKz6Q7P3jqr0EugNasCWn476P-zPwozPAPAxnKwadlz3S7DUa3FvDB2XLQdEI8rOvSkZTcITqKiIurRon4Fywldfm-p6DTsaNLzfXqXZUkFrkUVwxOswKTPKuMkElCHTjJZdNxSLwkr7bXSW3HyRvrI6J2MOl813zCFrm9YT9yP0pPecIaR9LZY?width=285&height=1217&cropmode=none", class: 'banner-about-img img-left' %>
-  <div class="banner-about__txt">
+  <section class="banner-buttons p-top-m p-bottom-l p-sides-m">
     <div class="p-bottom-m">
-        <h3 class="color-white"><%= I18n.t('root.about_title') %></h3>
+      <h3 class="color-yellow"><%= I18n.t('action.search_by') %></h3>
     </div>
-    <div>
-      <p class="color-white p-bottom-m"><%= I18n.t('root.about_text_p1') %></p>
-      <p class="color-white"><%= I18n.t('root.about_text_p2') %></p>
+    <div class="button-holder">
+        <%= link_to I18n.t('action.month').capitalize, item_seasons_path, class: 'link_action button button--yellow script-lg rotate-minus-5' %>
+        <%= link_to I18n.t('action.produce').capitalize, produce_items_path, class: 'link_action button button--yellow script-lg rotate-zero' %>
     </div>
-  </div>
-  <%= image_tag "https://dm2305files.storage.live.com/y4m9pwZq1iIqcdRBSt8VZEwJN6qA1UvxiiNXGFPETpPL4z08lKRDfpGUFuQ7CsrpYE0Vpou1Xgz-Gz4LcEd2mTKZyWSlfjXPzvinyXGo9SgxZwpiKxf6HWX6ui_Bn0s0uFQAd9Qxvccnz0ulEzPGQNW9CwIdfJtYP_89wi8HPn6ZdpqE9zWtZWO3GOMoJAwJgVF?width=269&height=1217&cropmode=none", class: 'banner-about-img img-right' %>
-</section>
+  </section>
+
+  <section class="banner-about p-top-m p-bottom-l">
+    <%= image_tag "https://dm2305files.storage.live.com/y4mYqMHpvb-2aKz6Q7P3jqr0EugNasCWn476P-zPwozPAPAxnKwadlz3S7DUa3FvDB2XLQdEI8rOvSkZTcITqKiIurRon4Fywldfm-p6DTsaNLzfXqXZUkFrkUVwxOswKTPKuMkElCHTjJZdNxSLwkr7bXSW3HyRvrI6J2MOl813zCFrm9YT9yP0pPecIaR9LZY?width=285&height=1217&cropmode=none", class: 'banner-about-img img-left' %>
+    <div class="banner-about__txt">
+      <div class="p-bottom-m">
+          <h3 class="color-white"><%= I18n.t('root.about_title') %></h3>
+      </div>
+      <div>
+        <p class="color-white p-bottom-m"><%= I18n.t('root.about_text_p1') %></p>
+        <p class="color-white"><%= I18n.t('root.about_text_p2') %></p>
+      </div>
+    </div>
+    <%= image_tag "https://dm2305files.storage.live.com/y4m9pwZq1iIqcdRBSt8VZEwJN6qA1UvxiiNXGFPETpPL4z08lKRDfpGUFuQ7CsrpYE0Vpou1Xgz-Gz4LcEd2mTKZyWSlfjXPzvinyXGo9SgxZwpiKxf6HWX6ui_Bn0s0uFQAd9Qxvccnz0ulEzPGQNW9CwIdfJtYP_89wi8HPn6ZdpqE9zWtZWO3GOMoJAwJgVF?width=269&height=1217&cropmode=none", class: 'banner-about-img img-right' %>
+  </section>
+</div>

--- a/app/views/item_seasons/index.html.erb
+++ b/app/views/item_seasons/index.html.erb
@@ -1,5 +1,5 @@
 <div class="content background-color-blue">
-  <h1 class="page__title banner-small"> <%= I18n.t("item_season.index.title") %> </h1>
+  <h1 class="page__title banner-small p-top-m p-bottom-m"> <%= I18n.t("item_season.index.title") %> </h1>
 
   <div class="button-holder p-top-l p-bottom-l">
     <% ItemSeason::MONTHS.each do |month_index| %>

--- a/app/views/item_seasons/index.html.erb
+++ b/app/views/item_seasons/index.html.erb
@@ -1,9 +1,9 @@
-<h1 class="page__title"> <%= I18n.t("item_season.index.title") %> </h1>
+<div class="content background-color-blue">
+  <h1 class="page__title banner-small"> <%= I18n.t("item_season.index.title") %> </h1>
 
-<table class="produce-table">
-  <% ItemSeason::MONTHS.each do |month_index| %>
-    <tr>
-      <td class="produce-table__month"><%= link_to (formatted_month_name(month_index)).capitalize, item_season_path(month_index), class: "link_action month_link" %></td>
-    </tr>
-  <%  end %>
-</table>
+  <div class="button-holder p-top-l p-bottom-l">
+    <% ItemSeason::MONTHS.each do |month_index| %>
+      <%= link_to (formatted_month_short(month_index)).capitalize, item_season_path(month_index), class: "link_action month_link button button--yellow script-lg" %>
+    <%  end %>
+  </div>
+</div>

--- a/app/views/item_seasons/index.html.erb
+++ b/app/views/item_seasons/index.html.erb
@@ -1,7 +1,7 @@
 <div class="content background-color-blue">
   <h1 class="page__title banner-small"> <%= I18n.t("item_season.index.title") %> </h1>
 
-  <div class="button-holder p-top-l p-bottom-l">
+  <div class="button-holder p-top-l p-bottom-l p-sides-s">
     <% ItemSeason::MONTHS.each do |month_index| %>
       <%= link_to (formatted_month_short(month_index)).capitalize, item_season_path(month_index),
           class: "link_action month_link button button--yellow script-lg m-top-s m-bottom-s #{randomized_rotation}" %>

--- a/app/views/item_seasons/index.html.erb
+++ b/app/views/item_seasons/index.html.erb
@@ -1,5 +1,5 @@
 <div class="content background-color-blue">
-  <h1 class="page__title banner-small p-top-m p-bottom-m"> <%= I18n.t("item_season.index.title") %> </h1>
+  <h1 class="page__title banner-small"> <%= I18n.t("item_season.index.title") %> </h1>
 
   <div class="button-holder p-top-l p-bottom-l">
     <% ItemSeason::MONTHS.each do |month_index| %>

--- a/app/views/item_seasons/index.html.erb
+++ b/app/views/item_seasons/index.html.erb
@@ -4,7 +4,7 @@
   <div class="button-holder p-top-l p-bottom-l">
     <% ItemSeason::MONTHS.each do |month_index| %>
       <%= link_to (formatted_month_short(month_index)).capitalize, item_season_path(month_index),
-          class: "link_action month_link button button--yellow script-lg m-top-s m-bottom-s #{sampled_rotation}" %>
+          class: "link_action month_link button button--yellow script-lg m-top-s m-bottom-s #{randomized_rotation}" %>
     <%  end %>
   </div>
 </div>

--- a/app/views/item_seasons/index.html.erb
+++ b/app/views/item_seasons/index.html.erb
@@ -3,7 +3,8 @@
 
   <div class="button-holder p-top-l p-bottom-l">
     <% ItemSeason::MONTHS.each do |month_index| %>
-      <%= link_to (formatted_month_short(month_index)).capitalize, item_season_path(month_index), class: "link_action month_link button button--yellow script-lg" %>
+      <%= link_to (formatted_month_short(month_index)).capitalize, item_season_path(month_index),
+          class: "link_action month_link button button--yellow script-lg m-top-s m-bottom-s #{sampled_rotation}" %>
     <%  end %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,7 @@
   <body>
     <% if notice %><div id="notice"><%= notice %></div><% end %>
     <%= render 'shared/navbar' %>
-    <div class="content">
-      <%= yield %>
-    </div>
+    <%= yield %>
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -37,6 +37,20 @@ pt-BR:
       - outubro
       - novembro
       - dezembro
+    month_short:
+      -
+      - jan
+      - fev
+      - mar
+      - abr
+      - mai
+      - jun
+      - jul
+      - ago
+      - set
+      - out
+      - nov
+      - dez
   produce_item:
     index:
       title: Itens

--- a/spec/features/item_seasons_spec.rb
+++ b/spec/features/item_seasons_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Item Seasons', type: :feature do
 
   it 'expects index to have a month' do
     visit(item_seasons_path)
-    expect(page).to have_css('table tr td.produce-table__month')
+    expect(page).to have_css('div a.link_action')
   end
 
   it 'expects the page to have one link per month' do
@@ -25,13 +25,13 @@ RSpec.describe 'Item Seasons', type: :feature do
 
   it 'expects "show" link to navigate to show' do
     visit(item_seasons_path)
-    first('table tr td a.link_action').click
+    first('div a.month_link').click
     expect(page).to have_css('table tr td.produce-table__name')
   end
 
   it 'expects "show" link to navigate to show and back to index' do
     visit(item_seasons_path)
-    first('table tr td a.link_action').click
+    first('div a.month_link').click
     find('.back').click
     expect(page).to have_current_path(item_seasons_path)
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,4 +18,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.formatted_month_name(1)).to eq('janeiro')
     end
   end
+
+  describe 'short month name' do
+    it 'changes the month_index to an abbr. month_name' do
+      expect(helper.formatted_month_short(1)).to eq('jan')
+    end
+  end
 end

--- a/spec/helpers/item_seasons_helper_spec.rb
+++ b/spec/helpers/item_seasons_helper_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ItemSeasonsHelper, type: :helper do
+  describe 'randomized rotation' do
+    it 'adds a random rotation to a button' do
+      expect(helper.randomized_rotation).to include('rotate')
+    end
+  end
+end

--- a/spec/views/item_seasons/index.html.erb_spec.rb
+++ b/spec/views/item_seasons/index.html.erb_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe 'item_seasons/index', type: :view do
   it 'displays the months' do
-    assign(:month_names, I18n.t('date.month_names'))
+    assign(:month_names, I18n.t('date.month_short'))
     render
-    expect(rendered).to match(/Janeiro/)
+    expect(rendered).to match(/Jan/)
   end
 end


### PR DESCRIPTION
closes #45 

First version of our item seasons index frontend.

**On desktop**
<img width="1266" alt="Screen Shot 2022-09-12 at 13 26 47" src="https://user-images.githubusercontent.com/87862340/189707490-38a3bdb4-c523-43a3-bed0-d3b7235a29f5.png">
<img width="1266" alt="Screen Shot 2022-09-12 at 13 26 51" src="https://user-images.githubusercontent.com/87862340/189707429-6ec510bc-1f4a-43ce-983f-d9ef4f0fdfb7.png">

**On mobile**
<img width="1120" alt="Screen Shot 2022-09-12 at 13 37 48" src="https://user-images.githubusercontent.com/87862340/189708854-e4732a45-4a4d-4ede-a6a0-677bfc7cb07d.png">
<img width="1120" alt="Screen Shot 2022-09-12 at 13 37 55" src="https://user-images.githubusercontent.com/87862340/189708889-51606216-fd7a-46ab-8fff-05d3c5273941.png">

**On surface pro**
<img width="1120" alt="Screen Shot 2022-09-12 at 13 37 29" src="https://user-images.githubusercontent.com/87862340/189708946-d2eb79f6-aa0c-4ff1-8b41-e04ccd1bb5dd.png">

**Short video**
https://user-images.githubusercontent.com/87862340/189708242-ad2d5ea3-a68f-469e-858b-3b6dcd451672.mov


**Of note**
Added two new helpers. One in item seasons for the rotation of the buttons, and one in application for the abbreviated months. Also added tests for both.
